### PR TITLE
Update UI strings to title case

### DIFF
--- a/app/(map)/scoreboard/[id]/page.tsx
+++ b/app/(map)/scoreboard/[id]/page.tsx
@@ -18,7 +18,7 @@ type PartialSite = Pick<
   "id" | "name" | "city" | "stateCode" | "category" | "npl" | "lat" | "lng"
 >;
 
-const pluralize = (count: number) => `${count} site${count === 1 ? "" : "s"}`;
+const pluralize = (count: number) => `${count} Site${count === 1 ? "" : "s"}`;
 
 type CollapsibleSiteListProps = {
   title: string;

--- a/app/(map)/scoreboard/[id]/page.tsx
+++ b/app/(map)/scoreboard/[id]/page.tsx
@@ -89,10 +89,10 @@ export default async function ScorePage({
   const siteNearest = siteMap.get(siteNearestId);
 
   const buckets = [
-    { title: "within 2 miles", ids: sites1 },
-    { title: "within 5 miles", ids: sites5 },
-    { title: "within 10 miles", ids: sites10 },
-    { title: "within 20 miles", ids: sites20 },
+    { title: "Within 2 Miles", ids: sites1 },
+    { title: "Within 5 Miles", ids: sites5 },
+    { title: "Within 10 Miles", ids: sites10 },
+    { title: "Within 20 Miles", ids: sites20 },
   ];
 
   return (
@@ -140,7 +140,7 @@ export default async function ScorePage({
           href={`/scoreboard/results?id=${id}`}
         >
           <SvgTrophy className="text-neutral-300" height={24} width={24} />
-          See your ranking
+          See Your Ranking
         </Link>
         {/*
           <Link

--- a/app/(map)/scoreboard/[id]/share.tsx
+++ b/app/(map)/scoreboard/[id]/share.tsx
@@ -22,7 +22,7 @@ export function ShareButton({ url }: { url: string }) {
       type="button"
     >
       <SvgShare className="text-neutral-600" height={24} width={24} />
-      {isShareAvailable ? "Share link" : "Copy link"}
+      {isShareAvailable ? "Share Link" : "Copy Link"}
     </button>
   );
 }

--- a/app/(map)/scoreboard/results/ResultsViewer.tsx
+++ b/app/(map)/scoreboard/results/ResultsViewer.tsx
@@ -92,7 +92,7 @@ export default function ResultsViewer({
         </div>
       )}
       <ListBox
-        aria-label="Scoreboard results"
+        aria-label="Scoreboard Results"
         className="flex-auto snap-y snap-mandatory overflow-y-auto border-neutral-300 border-t"
         disallowEmptySelection
         onSelectionChange={(key) => {

--- a/app/(map)/search-nearby.tsx
+++ b/app/(map)/search-nearby.tsx
@@ -157,7 +157,7 @@ export function SearchNearby() {
               disabled={pending}
               id="nearby-address"
               name="address"
-              placeholder="Enter an address"
+              placeholder="Enter an Address"
               type="text"
             />
             <Autocomplete.Portal>

--- a/app/(map)/sites/[site]/contaminants.tsx
+++ b/app/(map)/sites/[site]/contaminants.tsx
@@ -126,7 +126,7 @@ export async function Contaminants({
             height={20}
             width={20}
           />
-          <span className="sr-only">Learn about contamination types</span>
+          <span className="sr-only">Learn About Contamination Types</span>
         </Link>
       </WellTitle>
       {groups.map(([contextKey, sublist]) => (

--- a/app/(map)/sites/[site]/nearby.tsx
+++ b/app/(map)/sites/[site]/nearby.tsx
@@ -188,7 +188,7 @@ export async function Nearby({
 
   return (
     <WellRoot className="flex flex-col gap-y-1.5">
-      <WellTitle className="mb-1.5">Within 1 mile</WellTitle>
+      <WellTitle className="mb-1.5">Within 1 Mile</WellTitle>
       {nearbyFeatures.length > 0 &&
         nearbyFeatureGroups.map((group) => {
           const count = group.features.length;

--- a/app/(map)/sites/[site]/site.tsx
+++ b/app/(map)/sites/[site]/site.tsx
@@ -280,7 +280,7 @@ export function SiteCard({
 
       {suggestions.length > 0 && (
         <div className="flex w-full flex-col">
-          <Heading className="mb-1">Suggested questions</Heading>
+          <Heading className="mb-1">Suggested Questions</Heading>
           {suggestions.map((q) => (
             <button
               className="cursor-pointer text-balance border-zinc-300 border-b py-2 text-left text-xs text-zinc-600 transition-opacity last:border-b-0 hover:opacity-80"
@@ -307,7 +307,7 @@ export function SiteCard({
         <input
           className="action-button !bg-white w-full p-2"
           onChange={handleInputChange}
-          placeholder="Ask something…"
+          placeholder="Ask Something…"
           ref={ref}
           value={input}
         />

--- a/app/(map)/sites/[site]/timeline.tsx
+++ b/app/(map)/sites/[site]/timeline.tsx
@@ -30,7 +30,7 @@ export function SiteNPLStatusTimeline({ site }: { site: Site }) {
             height={20}
             width={20}
           />
-          <span className="sr-only">Learn about cleanup statuses</span>
+          <span className="sr-only">Learn About Cleanup Statuses</span>
         </Link>
       </WellTitle>
       <ul className="flex @md:flex-row flex-col @md:justify-between gap-1 @md:px-4 text-sm">

--- a/app/(map)/sites/search-sections.tsx
+++ b/app/(map)/sites/search-sections.tsx
@@ -34,7 +34,7 @@ export function SearchableSections({ sections }: { sections: Section[] }) {
         <input
           className="w-full p-2 outline-none"
           onChange={handleSearch}
-          placeholder="Search by county, city, state, or site name"
+          placeholder="Search by County, City, State, or Site Name"
           ref={ref}
           type="search"
           value={query}

--- a/app/(map)/sites/search.tsx
+++ b/app/(map)/sites/search.tsx
@@ -48,7 +48,7 @@ export function Search({ children }: React.PropsWithChildren<object>) {
           className="w-full p-2 outline-0"
           disabled={isLoading}
           onChange={handleSearch}
-          placeholder="Search by county, city, state, or site name"
+          placeholder="Search by County, City, State, or Site Name"
           ref={ref}
           type="search"
           value={query}


### PR DESCRIPTION
## Summary
- convert sentence-case UI labels and placeholders to title case across scoreboard, search, and site detail views
- align screen-reader labels with the updated visible copy where applicable
- standardize distance bucket labels and scoreboard action text

## Testing
- Not run (not requested)